### PR TITLE
モーダル部分の調整

### DIFF
--- a/src/app/threads/[threadId]/components/ThreadPostDialog.tsx
+++ b/src/app/threads/[threadId]/components/ThreadPostDialog.tsx
@@ -48,17 +48,24 @@ export const ThreadPostDialog: FC<{ threadId: string }> = ({ threadId }) => {
       <DialogTrigger>
         <ThreadPostButton />
       </DialogTrigger>
-      <DialogContent>
+      <DialogContent className="w-[90%] md:py-10 md:gap-6">
         <DialogHeader>
           <DialogTitle>投稿内容</DialogTitle>
         </DialogHeader>
         <form {...getFormProps(form)} action={action}>
-          <Textarea {...getTextareaProps(fields.post)} key={fields.post.key} />
+          <Textarea
+            {...getTextareaProps(fields.post)}
+            key={fields.post.key}
+            className="min-h-[160px] max-h-[300px] resize-none [field-sizing:content]"
+          />
           <p className="text-sm text-red-500">{fields.post.errors}</p>
           <p className="text-sm text-muted-foreground">140文字以内</p>
           <input type="hidden" name="threadId" value={threadId} />
           <Button
-            className={cn({ 'cursor-not-allowed': !form.valid || isPending })}
+            className={cn(
+              { 'cursor-not-allowed': !form.valid || isPending },
+              'block w-[min(100%,320px)] mt-4 mx-auto py-3 md:text-lg md:py-4 md:mt-6 !h-auto text-foreground'
+            )}
             disabled={!form.valid || isPending}
           >
             投稿する

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -44,7 +44,10 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close
+        className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground"
+        autoFocus
+      >
         <X className="!h-8 !w-8" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>


### PR DESCRIPTION
モーダルのレイアウトの調整と初期フォーカス位置の調整。
投稿モーダルをクローズしたときに画面の一番下までスクロールしてしまう現象が起きているので別Issueにて対応。





close #50