### PR TITLE
licenseページにサインアウトボタンを設置

### DIFF
--- a/src/app/license/components/InviteCodeForm.tsx
+++ b/src/app/license/components/InviteCodeForm.tsx
@@ -2,6 +2,7 @@
 
 import { getFormProps, getInputProps, useForm } from '@conform-to/react';
 import { getZodConstraint, parseWithZod } from '@conform-to/zod';
+import { Loader2 } from 'lucide-react';
 import type { FC } from 'react';
 import { useActionState } from 'react';
 
@@ -32,12 +33,27 @@ export const InviteCodeForm: FC = () => {
     <form action={formAction} {...getFormProps(form)} className="mt-6">
       <Input {...getInputProps(fields.inviteCode, { type: 'text' })} key={fields.inviteCode.key} />
       <p className="text-sm text-red-500">{fields.inviteCode.errors}</p>
-      <Button
-        className={cn({ 'cursor-not-allowed': !form.valid || isPending }, 'mt-6')}
-        disabled={!form.valid || isPending}
-      >
-        招待コードを送信
-      </Button>
+      {isPending ? (
+        <Button
+          className="flex items-center w-[min(100%,320px)] mx-auto py-3 mt-6 md:text-lg md:py-4 !h-auto text-foreground cursor-not-allowed !pointer-events-auto hover:bg-primary"
+          disabled
+        >
+          <Loader2 className="size-4 mr-2 sm:size-5 animate-spin" />
+          招待コード確認中
+        </Button>
+      ) : (
+        <Button
+          className={cn(
+            {
+              'cursor-not-allowed !pointer-events-auto hover:bg-primary': !form.valid,
+            },
+            'block w-[min(100%,320px)] mx-auto py-3 mt-6 md:text-lg md:py-4 !h-auto text-foreground'
+          )}
+          disabled={!form.valid}
+        >
+          招待コードを送信
+        </Button>
+      )}
     </form>
   );
 };

--- a/src/app/license/components/SignOutButton.tsx
+++ b/src/app/license/components/SignOutButton.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { Loader2, LogOut } from 'lucide-react';
+import type { FC } from 'react';
+import { useFormStatus } from 'react-dom';
+
+export const SignOutButton: FC = () => {
+  const { pending } = useFormStatus();
+
+  return (
+    <>
+      {pending ? (
+        <button
+          className="flex items-center gap-3 text-red-800 py-2 px-3 sm:gap-5 sm:text-xl"
+          disabled
+        >
+          <Loader2 className="size-4 sm:size-5 animate-spin" />
+          ログアウト処理中
+        </button>
+      ) : (
+        <button className="flex items-center gap-3 text-red-800 py-2 px-3 transition-colors hover:text-red-500 sm:gap-5 sm:text-xl">
+          <LogOut className="size-4 sm:size-5" />
+          ログアウト
+        </button>
+      )}
+    </>
+  );
+};

--- a/src/app/license/page.tsx
+++ b/src/app/license/page.tsx
@@ -3,8 +3,9 @@ import { redirect } from 'next/navigation';
 
 import { HeadingPage } from '@/app/components/heading/HeadingPage';
 import { LayoutPadding } from '@/app/components/layout/LayoutPadding';
-import { auth } from '@/app/lib/auth';
+import { auth, signOut } from '@/app/lib/auth';
 import { InviteCodeForm } from '@/app/license/components/InviteCodeForm';
+import { SignOutButton } from '@/app/license/components/SignOutButton';
 import { metadata as defaultMetadata } from '@/app/utils/metadata';
 import { SITE_NAME, SITE_URL } from '@/app/utils/siteSettings';
 
@@ -31,7 +32,17 @@ export default async function License() {
   return (
     <LayoutPadding>
       <HeadingPage>招待コード入力</HeadingPage>
+      <p className="pt-6">お友達にもらった招待コードを入力してね！</p>
       <InviteCodeForm />
+      <form
+        className="w-fit mx-auto mt-6"
+        action={async () => {
+          'use server';
+          await signOut();
+        }}
+      >
+        <SignOutButton />
+      </form>
     </LayoutPadding>
   );
 }


### PR DESCRIPTION
close #101

サインアウトボタン設置のついでに招待コード入力ページのボタンの送信中スタイルあてた。