### PR TITLE
スレッドの順序を古い順に変更、リアクションボタン修正

### DIFF
--- a/src/app/threads/[threadId]/components/ThreadConversationList.tsx
+++ b/src/app/threads/[threadId]/components/ThreadConversationList.tsx
@@ -27,9 +27,7 @@ export const ThreadConversationList: FC<Props> = async ({
   });
 
   const posts = await prisma.post.findMany({
-    where: {
-      threadId: threadId,
-    },
+    where: { threadId },
     orderBy: {
       createdAt: 'desc',
     },
@@ -39,6 +37,9 @@ export const ThreadConversationList: FC<Props> = async ({
     skip: (currentPage - 1) * postsPerPage,
     take: postsPerPage,
   });
+
+  // ページの最初の投稿番号を計算
+  const startNumber = totalPosts - (currentPage - 1) * postsPerPage - (posts.length - 1);
 
   return (
     <>
@@ -50,12 +51,9 @@ export const ThreadConversationList: FC<Props> = async ({
             {'< ﾋﾟｴﾝ'}
           </li>
         ) : (
-          posts.map((post, index) => (
+          posts.reverse().map((post, index) => (
             <li className="relative border-t last-of-type:border-b p-4 pt-2" key={post.id}>
-              <ThreadPostDrawer
-                threadId={threadId}
-                replyNumber={totalPosts - (currentPage - 1) * postsPerPage - index}
-              >
+              <ThreadPostDrawer threadId={threadId} replyNumber={startNumber + index}>
                 <Button size="icon" className="absolute right-2 top-2 size-6 rounded-full">
                   <Reply color="white" />
                 </Button>
@@ -63,9 +61,7 @@ export const ThreadConversationList: FC<Props> = async ({
 
               <div className="grid gap-1">
                 <div className="flex items-center gap-4">
-                  <div className="text-sm text-muted-foreground">
-                    #{totalPosts - (currentPage - 1) * postsPerPage - index}
-                  </div>
+                  <div className="text-sm text-muted-foreground">#{startNumber + index}</div>
                   <div className="flex items-center gap-2 text-sm text-muted-foreground">
                     <CalendarDays size={'1em'} />
                     {dayjs(post.createdAt).tz().format('YYYY-MM-DD HH:mm')}

--- a/src/app/threads/[threadId]/components/ThreadReactionButton.tsx
+++ b/src/app/threads/[threadId]/components/ThreadReactionButton.tsx
@@ -37,12 +37,12 @@ export const ThreadReactionButton: FC<Props> = ({
       } else {
         return currentState.filter((user) => user.id !== currentUser.id);
       }
-    }
+    },
   );
 
   // 自分がリアクションをしているかどうか
   const optimisticReactionState = optimisticReactionUsers.some(
-    (user) => user.id === currentUser?.id
+    (user) => user.id === currentUser?.id,
   );
 
   return (
@@ -58,11 +58,11 @@ export const ThreadReactionButton: FC<Props> = ({
       <input type="hidden" name="state" value={String(!optimisticReactionState)} />
       <Button
         variant="outline"
-        className={cn('rounded-full h-auto px-2 py-0', {
+        className={cn('rounded-full h-auto px-2 py-[0.1em] gap-1', {
           'bg-primary text-white hover:bg-primary hover:text-white': optimisticReactionState,
         })}
       >
-        <span className="text-lg">{children}</span> {optimisticReactionUsers.length}
+        <span>{children}</span> {optimisticReactionUsers.length}
       </Button>
     </form>
   );


### PR DESCRIPTION
友人からも上が新しいと見ずらいと言われた。
Twitterは上が新しいやつ！と思ったけど、結局は古いものから上（新しいやつ）を見に行っているし、返信したときも古い順に並んでいるので古い順に戻した。
ついでにリアクションボタンのスタイルも微調整した。